### PR TITLE
Update output name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following outputs can be used by subsequent workflow steps.
 
 | Name | Description |
 | --- | --- |
-| `config-path` | Path to the configuration file |
+| `path` | Path to the configuration file |
 
 ## Releasing
 

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     description: Github access token, required for private repositories
 outputs:
-  config-path:
+  path:
     description: The tflint configuration file path
 runs:
   using: 'node12'

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ async function run(): Promise<void> {
 
   try {
     core.setOutput(
-      'config-path',
+      'path',
       await fetchFileToLocal({
         owner,
         repo,


### PR DESCRIPTION
Change output from config-path to just path. The action is called remote-tflint-config so adding the config prefix to the output is redundant